### PR TITLE
Switched the node removal path to call the bridge’s dedicated removal…

### DIFF
--- a/app/node/__init__.py
+++ b/app/node/__init__.py
@@ -103,7 +103,7 @@ class NodeManager:
         proto_user = serialize_user_for_node(user.id, user.username, user.proxy_settings.dict())
 
         async with self._lock.reader_lock:
-            remove_tasks = [node.update_user(proto_user) for node in self._nodes.values()]
+            remove_tasks = [node.remove_user(proto_user) for node in self._nodes.values()]
             await asyncio.gather(*remove_tasks, return_exceptions=True)
 
 


### PR DESCRIPTION
… API rather than reusing the update call, so users marked for deletion are actually dropped from connected nodes