### PR TITLE
Updated SQL cleanup queries to use SQLAlchemy’s supported notin_ oper…

### DIFF
--- a/app/db/crud/host.py
+++ b/app/db/crud/host.py
@@ -44,7 +44,7 @@ async def get_inbounds_not_in_tags(db: AsyncSession, excluded_tags: List[str]) -
     Returns:
         List of ProxyInbound objects not matching any tag in the list
     """
-    stmt = select(ProxyInbound).where(ProxyInbound.tag.not_in(excluded_tags))
+    stmt = select(ProxyInbound).where(ProxyInbound.tag.notin_(excluded_tags))
     result = await db.execute(stmt)
     return result.scalars().all()
 

--- a/app/jobs/cleanup_subscription_updates.py
+++ b/app/jobs/cleanup_subscription_updates.py
@@ -44,7 +44,7 @@ async def cleanup_user_subscription_updates():
                     # Delete records not in keep list
                     result = await db.execute(
                         delete(UserSubscriptionUpdate).where(
-                            UserSubscriptionUpdate.user_id == user_id, UserSubscriptionUpdate.id.not_in(keep_ids)
+                            UserSubscriptionUpdate.user_id == user_id, UserSubscriptionUpdate.id.notin_(keep_ids)
                         )
                     )
                     total_deleted += result.rowcount
@@ -63,7 +63,7 @@ async def cleanup_user_subscription_updates():
 
             result = await db.execute(
                 delete(UserSubscriptionUpdate).where(
-                    UserSubscriptionUpdate.user_id.in_(user_ids), UserSubscriptionUpdate.id.not_in(keep_subquery)
+                    UserSubscriptionUpdate.user_id.in_(user_ids), UserSubscriptionUpdate.id.notin_(keep_subquery)
                 )
             )
             logger.info(f"Cleaned up {result.rowcount} old subscription updates")


### PR DESCRIPTION
…ators, preventing AttributeErrors that previously stopped subscription/pruning jobs from deleting stale records